### PR TITLE
feat(renderer): add titlecase transformation

### DIFF
--- a/src/renderer/helpers.rs
+++ b/src/renderer/helpers.rs
@@ -39,6 +39,23 @@ pub fn lowercase_helper(
   Ok(())
 }
 
+pub fn titlecase_helper(
+  h: &Helper,
+  _: &Handlebars,
+  _: &Context,
+  _: &mut RenderContext,
+  out: &mut dyn Output,
+) -> Result<(), RenderError> {
+  // get parameter from helper or throw an error
+  let param = h
+      .param(0)
+      .ok_or(RenderError::new("Param 0 is required for format helper."))?;
+
+  let rendered = param.value().render().to_string().to_case(Case::Title);
+  out.write(rendered.as_ref())?;
+  Ok(())
+}
+
 pub fn camelcase_helper(
   h: &Helper,
   _: &Handlebars,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -24,6 +24,7 @@ pub fn render(text: &str, content: &Context) -> String {
   // register helper methods
   handlebars.register_helper("uppercase", Box::new(helpers::uppercase_helper));
   handlebars.register_helper("lowercase", Box::new(helpers::lowercase_helper));
+  handlebars.register_helper("titlecase", Box::new(helpers::titlecase_helper));
   handlebars.register_helper("camelcase", Box::new(helpers::camelcase_helper));
   handlebars.register_helper("pascalcase", Box::new(helpers::pascalcase_helper));
   handlebars.register_helper("snakecase", Box::new(helpers::snakecase_helper));
@@ -103,7 +104,7 @@ mod tests {
   #[test]
   fn test_render_transformation_values() -> Result<(), Box<dyn std::error::Error>> {
     let text =
-      "{{ camelcase values.full_name }},{{ constantcase values.full_name }},{{ kebabcase values.full_name }},{{ lowercase values.full_name }},{{ pascalcase values.full_name }},{{ snakecase values.full_name }},{{ uppercase values.full_name }}";
+      "{{ camelcase values.full_name }},{{ constantcase values.full_name }},{{ kebabcase values.full_name }},{{ lowercase values.full_name }},{{ pascalcase values.full_name }},{{ snakecase values.full_name }},{{ uppercase values.full_name }},{{ titlecase values.full_name }}";
     let mut values = HashMap::new();
     values.insert(String::from("full_name"), String::from("ThomasPöhlmann"));
     let content: Context = Context {
@@ -118,7 +119,7 @@ mod tests {
 
     assert_eq!(
       result,
-      "thomasPöhlmann,THOMAS_PÖHLMANN,thomas-pöhlmann,thomaspöhlmann,ThomasPöhlmann,thomas_pöhlmann,THOMASPÖHLMANN"
+      "thomasPöhlmann,THOMAS_PÖHLMANN,thomas-pöhlmann,thomaspöhlmann,ThomasPöhlmann,thomas_pöhlmann,THOMASPÖHLMANN,Thomas Pöhlmann"
     );
 
     Ok(())


### PR DESCRIPTION
Partially resolves #139 

see [title case docs](https://docs.rs/convert_case/0.4.0/convert_case/enum.Case.html#variant.Title)

@perryrh0dan [sentence case](https://github.com/blakeembrey/change-case/blob/master/packages/sentence-case/src/index.spec.ts) would also be nice to have but looks like convert case does not support it